### PR TITLE
docs(core): add mkdocs for documentation site

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,5 @@ coverage/
 .eslintrc.js
 .cz-config.js
 commitlint.config.js
+docs/
+site/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: ci
+on:
+  push:
+    branches:
+      - main
+permissions:
+  contents: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+      - name: Setup Node
+        uses: actions/setup-node@v3.6.0
+        with:
+          node-version: '18.x'
+      - name: Bootstrap
+        run: npm ci
+      - name: Install mkdocs deps/plugins
+        run: |
+          pip install mkdocs-material
+          pip install mkdocs-include-markdown-plugin
+      - name: Create the docs directory locally in CI
+        run: npx typedoc
+      - name: Deploy 🚀
+        run: mkdocs gh-deploy --force

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,10 @@ typings/
 *.tsbuildinfo
 
 /src/sequelize/usercrud.sequelize.repository.base.ts
+
+# site contains compiled html files, we don't need them because mkdocs-deploy
+# can freshly recreate them
+/site
+
+# api-reference
+/docs/api-reference

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,4 @@
 dist
 *.json
+docs
+site

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![LoopBack](<https://github.com/loopbackio/loopback-next/raw/master/docs/site/imgs/branding/Powered-by-LoopBack-Badge-(blue)-@2x.png>)](http://loopback.io/)
 
+<!-- docs-index-start -->
+
 This is a loopback4 extension that provides Sequelize's query builder at repository level in any loopback 4 application. It has zero learning curve as it follows similar interface as `DefaultCrudRepository`. For relational databases, Sequelize is a popular ORM of choice.
 
 For pending features, refer to the [Limitations](#limitations) section below.
@@ -30,13 +32,15 @@ npm install --save oracledb # Oracle Database
 
 > You can watch a video overview of this extension by [clicking here](https://youtu.be/ZrUxIk63oRc).
 
+<!-- tutorial-start -->
+
 Both newly developed and existing projects can benefit from the extension by simply changing the parent classes in the target Data Source and Repositories.
 
 ### Step 1: Configure DataSource
 
 Change the parent class from `juggler.DataSource` to `SequelizeDataSource` like below.
 
-```ts
+```ts title="pg.datasource.ts"
 // ...
 import {SequelizeDataSource} from 'loopback4-sequelize';
 
@@ -52,7 +56,7 @@ export class PgDataSource
 
 Change the parent class from `DefaultCrudRepository` to `SequelizeCrudRepository` like below.
 
-```ts
+```ts title="your.repository.ts"
 // ...
 import {SequelizeCrudRepository} from 'loopback4-sequelize';
 
@@ -103,6 +107,8 @@ An example of the filter object might look like this to fetch the books who cont
   ]
 }
 ```
+
+<!-- tutorial-end -->
 
 ## Debug strings reference
 
@@ -163,3 +169,5 @@ Code of conduct guidelines [here](https://github.com/sourcefuse/loopback4-sequel
 ## License
 
 [MIT](https://github.com/sourcefuse/loopback4-sequelize/blob/master/LICENSE)
+
+<!-- docs-index-end -->

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,9 @@
+---
+title: Overview
+---
+
+{%
+   include-markdown "../README.md"
+   start="<!-- docs-index-start -->"
+   end='<!-- docs-index-end -->'
+%}

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -1,0 +1,7 @@
+# Basics
+
+{%
+   include-markdown "../../README.md"
+   start="<!-- tutorial-start -->"
+   end='<!-- tutorial-end -->'
+%}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,41 @@
+site_name: Loopback4 Sequelize
+
+theme:
+  name: material
+  features:
+    - content.code.copy
+  palette:
+    - scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+docs_dir: docs
+
+markdown_extensions:
+  - tables
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+
+extra:
+  generator: false
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/sourcefuse/loopback4-sequelize
+
+plugins:
+  - search
+  - include-markdown
+
+repo_name: sourcefuse/loopback4-sequelize
+repo_url: https://github.com/sourcefuse/loopback4-sequelize
+
+copyright: |
+  &copy; 2023 <a href="https://github.com/sourcefuse/loopback4-microservice-catalog" target="_blank" rel="noopener">Sourceloop</a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "loopback4-sequelize",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "loopback4-sequelize",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -39,6 +39,8 @@
         "semantic-release": "^19.0.5",
         "source-map-support": "^0.5.21",
         "sqlite3": "^5.1.2",
+        "typedoc": "^0.23.23",
+        "typedoc-plugin-markdown": "^3.14.0",
         "typescript": "~4.7.4"
       },
       "engines": {
@@ -6933,6 +6935,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -7293,6 +7301,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -7400,9 +7414,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.1.1.tgz",
-      "integrity": "sha512-0cNMnTcUJPxbA6uWmCmjWz4NJRe/0Xfk2NhXCUHjew9qJzFN20krFnsUe7QynwqOwa5m1fZ4UDg0ycKFVC0ccw==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.5.tgz",
+      "integrity": "sha512-jPueVhumq7idETHkb203WDD4fMA3yV9emQ5vLwop58lu8bTclMghBWcYAavlDqIEMaisADinV1TooIFCfqOsYQ==",
       "dev": true,
       "bin": {
         "marked": "bin/marked.js"
@@ -12895,6 +12909,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/shiki": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.11.1.tgz",
+      "integrity": "sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==",
+      "dev": true,
+      "dependencies": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-oniguruma": "^1.6.1",
+        "vscode-textmate": "^6.0.0"
+      }
+    },
     "node_modules/should": {
       "version": "13.2.3",
       "resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
@@ -13931,6 +13956,60 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typedoc": {
+      "version": "0.23.23",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.23.tgz",
+      "integrity": "sha512-cg1YQWj+/BU6wq74iott513U16fbrPCbyYs04PHZgvoKJIc6EY4xNobyDZh4KMfRGW8Yjv6wwIzQyoqopKOUGw==",
+      "dev": true,
+      "dependencies": {
+        "lunr": "^2.3.9",
+        "marked": "^4.2.4",
+        "minimatch": "^5.1.1",
+        "shiki": "^0.11.1"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 14.14"
+      },
+      "peerDependencies": {
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x"
+      }
+    },
+    "node_modules/typedoc-plugin-markdown": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.14.0.tgz",
+      "integrity": "sha512-UyQLkLRkfTFhLdhSf3RRpA3nNInGn+k6sll2vRXjflaMNwQAAiB61SYbisNZTg16t4K1dt1bPQMMGLrxS0GZ0Q==",
+      "dev": true,
+      "dependencies": {
+        "handlebars": "^4.7.7"
+      },
+      "peerDependencies": {
+        "typedoc": ">=0.23.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/typescript": {
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
@@ -14147,6 +14226,18 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "dev": true
+    },
+    "node_modules/vscode-textmate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-6.0.0.tgz",
+      "integrity": "sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==",
+      "dev": true
     },
     "node_modules/wcwidth": {
       "version": "1.0.1",
@@ -19785,6 +19876,12 @@
       "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==",
       "dev": true
     },
+    "jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
     "jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -20087,6 +20184,12 @@
         "yallist": "^4.0.0"
       }
     },
+    "lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -20171,9 +20274,9 @@
       "dev": true
     },
     "marked": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.1.1.tgz",
-      "integrity": "sha512-0cNMnTcUJPxbA6uWmCmjWz4NJRe/0Xfk2NhXCUHjew9qJzFN20krFnsUe7QynwqOwa5m1fZ4UDg0ycKFVC0ccw==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.5.tgz",
+      "integrity": "sha512-jPueVhumq7idETHkb203WDD4fMA3yV9emQ5vLwop58lu8bTclMghBWcYAavlDqIEMaisADinV1TooIFCfqOsYQ==",
       "dev": true
     },
     "marked-terminal": {
@@ -24151,6 +24254,17 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
+    "shiki": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.11.1.tgz",
+      "integrity": "sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==",
+      "dev": true,
+      "requires": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-oniguruma": "^1.6.1",
+        "vscode-textmate": "^6.0.0"
+      }
+    },
     "should": {
       "version": "13.2.3",
       "resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
@@ -24970,6 +25084,47 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typedoc": {
+      "version": "0.23.23",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.23.tgz",
+      "integrity": "sha512-cg1YQWj+/BU6wq74iott513U16fbrPCbyYs04PHZgvoKJIc6EY4xNobyDZh4KMfRGW8Yjv6wwIzQyoqopKOUGw==",
+      "dev": true,
+      "requires": {
+        "lunr": "^2.3.9",
+        "marked": "^4.2.4",
+        "minimatch": "^5.1.1",
+        "shiki": "^0.11.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
+          "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
+      }
+    },
+    "typedoc-plugin-markdown": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.14.0.tgz",
+      "integrity": "sha512-UyQLkLRkfTFhLdhSf3RRpA3nNInGn+k6sll2vRXjflaMNwQAAiB61SYbisNZTg16t4K1dt1bPQMMGLrxS0GZ0Q==",
+      "dev": true,
+      "requires": {
+        "handlebars": "^4.7.7"
+      }
+    },
     "typescript": {
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
@@ -25132,6 +25287,18 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true
+    },
+    "vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "dev": true
+    },
+    "vscode-textmate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-6.0.0.tgz",
+      "integrity": "sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==",
       "dev": true
     },
     "wcwidth": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "test:dev": "lb-mocha --allow-console-logs dist/__tests__/**/*.js && npm run posttest",
     "clean": "lb-clean dist *.tsbuildinfo .eslintcache",
     "prepare": "husky install",
-    "rebuild": "npm run clean && npm run build"
+    "rebuild": "npm run clean && npm run build",
+    "export-api-ref": "npx typedoc"
   },
   "repository": {
     "type": "git",
@@ -80,6 +81,8 @@
     "semantic-release": "^19.0.5",
     "source-map-support": "^0.5.21",
     "sqlite3": "^5.1.2",
+    "typedoc": "^0.23.23",
+    "typedoc-plugin-markdown": "^3.14.0",
     "typescript": "~4.7.4"
   },
   "config": {

--- a/src/sequelize/sequelize.datasource.base.ts
+++ b/src/sequelize/sequelize.datasource.base.ts
@@ -10,6 +10,9 @@ import {
 const debug = debugFactory('loopback:sequelize:datasource');
 const queryLogging = debugFactory('loopback:sequelize:queries');
 
+/**
+ * Sequelize DataSource Class
+ */
 export class SequelizeDataSource implements LifeCycleObserver {
   name: string;
   settings = {};

--- a/src/sequelize/sequelize.repository.base.ts
+++ b/src/sequelize/sequelize.repository.base.ts
@@ -77,6 +77,7 @@ export class SequelizeCrudRepository<
       this.sequelizeModel = this.getSequelizeModel();
     }
   }
+
   /**
    * Default `order` filter style if only column name is specified
    */
@@ -85,14 +86,14 @@ export class SequelizeCrudRepository<
   /**
    * Object keys used in models for set database specific settings.
    * Example: In model property definition one can use postgresql dataType as float
-   * {
+   * `{
    *   type: 'number',
    *   postgresql: {
    *     dataType: 'float',
    *     precision: 20,
    *     scale: 4,
    *   },
-   * }
+   * }`
    *
    * This array of keys is used while building model definition for sequelize.
    */

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,6 @@
+{
+  "entryPoints": ["src/index.ts"],
+  "out": "docs/api-reference",
+  "plugin": ["typedoc-plugin-markdown"],
+  "readme": "none"
+}


### PR DESCRIPTION
- Added and configured [mkdocs](https://squidfunk.github.io/mkdocs-material/) for documentation site
- Added and configured [typedoc](https://typedoc.org/) for exporting api references as markdown files inside mkdocs's docs_dir
- Added `ci.yml` in github workflow to deploy documentation site on every push to master branch.

GH-9