### PR TITLE
feat(datasource): implement connection pooling and sequelize specific options support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,27 @@ export class PgDataSource
 }
 ```
 
+`SequelizeDataSource` accepts commonly used config in the same way as loopback did. So in most cases you won't need to change your existing configuration. But if you want to use sequelize specific options pass them in `sequelizeOptions` like below:
+
+```ts
+let config = {
+  name: 'db',
+  connector: 'postgresql',
+  sequelizeOptions: {
+    username: 'postgres',
+    password: 'secret',
+    dialectOptions: {
+      ssl: {
+        rejectUnauthorized: false,
+        ca: fs.readFileSync('/path/to/root.crt').toString(),
+      },
+    },
+  },
+};
+```
+
+> Note: Options provided in `sequelizeOptions` will take priority over others, For eg. if you have password specified in both `config.password` and `config.password.sequelizeOptions` the latter one will be used.
+
 ### Step 2: Configure Repository
 
 Change the parent class from `DefaultCrudRepository` to `SequelizeCrudRepository` like below.
@@ -219,7 +240,6 @@ There are three built-in debug strings available in this extension to aid in deb
 Please note, the current implementation does not support the following:
 
 1. Loopback Migrations (via default `migrate.ts`). Though you're good if using external packages like [`db-migrate`](https://www.npmjs.com/package/db-migrate).
-2. Connection Pooling is not implemented yet.
 
 Community contribution is welcome.
 

--- a/src/__tests__/fixtures/datasources/config.ts
+++ b/src/__tests__/fixtures/datasources/config.ts
@@ -8,7 +8,7 @@ type AvailableConfig = Record<
 >;
 
 export const datasourceTestConfig: Record<
-  'primary' | 'secondary',
+  'primary' | 'secondary' | 'url' | 'wrongPassword',
   AvailableConfig
 > = {
   primary: {
@@ -45,6 +45,28 @@ export const datasourceTestConfig: Record<
       connector: 'sqlite3',
       database: 'transaction-secondary',
       file: ':memory:',
+    },
+  },
+  url: {
+    postgresql: {
+      name: 'using-url',
+      connector: 'postgresql',
+      url: 'postgres://postgres:super-secret@localhost:5002/postgres',
+    },
+    sqlite3: {
+      name: 'using-url',
+      url: 'sqlite::memory:',
+    },
+  },
+  wrongPassword: {
+    postgresql: {
+      name: 'wrongPassword',
+      connector: 'postgresql',
+      url: 'postgres://postgres:super-secret-wrong@localhost:5002/postgres',
+    },
+    sqlite3: {
+      name: 'wrongPassword',
+      url: 'sqlite::memory:',
     },
   },
 };

--- a/src/__tests__/unit/sequelize.datasource.unit.ts
+++ b/src/__tests__/unit/sequelize.datasource.unit.ts
@@ -16,4 +16,54 @@ describe('Sequelize DataSource', () => {
       expect(result).which.eql('Specified connector memory is not supported.');
     }
   });
+
+  it('parses pool options for postgresql', async () => {
+    const dataSource = new SequelizeDataSource({
+      name: 'db',
+      connector: 'postgresql',
+      min: 10,
+      max: 20,
+      idleTimeoutMillis: 18000,
+    });
+
+    const poolOptions = dataSource.getPoolOptions();
+
+    expect(poolOptions).to.have.property('min', 10);
+    expect(poolOptions).to.have.property('max', 20);
+    expect(poolOptions).to.have.property('idle', 18000);
+    expect(poolOptions).to.not.have.property('acquire');
+  });
+
+  it('parses pool options for mysql', async () => {
+    const dataSource = new SequelizeDataSource({
+      name: 'db',
+      connector: 'mysql',
+      connectionLimit: 20,
+      acquireTimeout: 10000,
+    });
+
+    const poolOptions = dataSource.getPoolOptions();
+
+    expect(poolOptions).to.have.property('max', 20);
+    expect(poolOptions).to.have.property('acquire', 10000);
+    expect(poolOptions).to.not.have.property('min');
+    expect(poolOptions).to.not.have.property('idle');
+  });
+
+  it('parses pool options for oracle', async () => {
+    const dataSource = new SequelizeDataSource({
+      name: 'db',
+      connector: 'oracle',
+      minConn: 10,
+      maxConn: 20,
+      timeout: 20000,
+    });
+
+    const poolOptions = dataSource.getPoolOptions();
+
+    expect(poolOptions).to.have.property('min', 10);
+    expect(poolOptions).to.have.property('max', 20);
+    expect(poolOptions).to.have.property('idle', 20000);
+    expect(poolOptions).to.not.have.property('acquire');
+  });
 });

--- a/src/__tests__/unit/sequelize.datasource.unit.ts
+++ b/src/__tests__/unit/sequelize.datasource.unit.ts
@@ -1,6 +1,8 @@
 import {expect} from '@loopback/testlab';
 import {SequelizeDataSource} from '../../sequelize';
 import {SupportedLoopbackConnectors} from '../../sequelize/connector-mapping';
+import {datasourceTestConfig} from '../fixtures/datasources/config';
+import {config as primaryDataSourceConfig} from '../fixtures/datasources/primary.datasource';
 
 describe('Sequelize DataSource', () => {
   it('throws error when nosql connectors are supplied', () => {
@@ -15,6 +17,50 @@ describe('Sequelize DataSource', () => {
       const result = err.message;
       expect(result).which.eql('Specified connector memory is not supported.');
     }
+  });
+
+  it('accepts url strings for connection', async () => {
+    const dataSource = new SequelizeDataSource(
+      datasourceTestConfig.url[
+        primaryDataSourceConfig.connector === 'postgresql'
+          ? 'postgresql'
+          : 'sqlite3'
+      ],
+    );
+    expect(await dataSource.init()).to.not.throwError();
+    await dataSource.stop();
+  });
+
+  it('throws error if url strings has wrong password', async function () {
+    if (primaryDataSourceConfig.connector !== 'postgresql') {
+      // eslint-disable-next-line @typescript-eslint/no-invalid-this
+      this.skip();
+    }
+    const dataSource = new SequelizeDataSource(
+      datasourceTestConfig.wrongPassword.postgresql,
+    );
+    try {
+      await dataSource.init();
+    } catch (err) {
+      expect(err.message).to.be.eql(
+        'password authentication failed for user "postgres"',
+      );
+    }
+  });
+
+  it('should be able override sequelize options', async function () {
+    if (primaryDataSourceConfig.connector !== 'postgresql') {
+      // eslint-disable-next-line @typescript-eslint/no-invalid-this
+      this.skip();
+    }
+    const dataSource = new SequelizeDataSource({
+      ...datasourceTestConfig.primary.postgresql,
+      user: 'wrong-username', // expected to be overridden
+      sequelizeOptions: {
+        username: datasourceTestConfig.primary.postgresql.user,
+      },
+    });
+    expect(await dataSource.init()).to.not.throwError();
   });
 
   it('parses pool options for postgresql', async () => {

--- a/src/sequelize/connector-mapping.ts
+++ b/src/sequelize/connector-mapping.ts
@@ -1,4 +1,4 @@
-import {Dialect as AllSequelizeDialects} from 'sequelize';
+import {Dialect as AllSequelizeDialects, PoolOptions} from 'sequelize';
 
 export type SupportedLoopbackConnectors =
   | 'mysql'
@@ -18,4 +18,56 @@ export const SupportedConnectorMapping: {
   oracle: 'oracle',
   sqlite3: 'sqlite',
   db2: 'db2',
+};
+
+/**
+ * Loopback uses different keys for pool options depending on the connector.
+ */
+export const poolConfigKeys = [
+  // mysql
+  'connectionLimit',
+  'acquireTimeout',
+  // postgresql
+  'min',
+  'max',
+  'idleTimeoutMillis',
+  // oracle
+  'minConn',
+  'maxConn',
+  'timeout',
+] as const;
+export type LoopbackPoolConfigKey = (typeof poolConfigKeys)[number];
+
+export type PoolingEnabledConnector = Exclude<
+  SupportedLoopbackConnectors,
+  'db2' | 'sqlite3'
+>;
+
+export const poolingEnabledConnectors: PoolingEnabledConnector[] = [
+  'mysql',
+  'oracle',
+  'postgresql',
+];
+
+type IConnectionPoolOptions = {
+  [connectorName in PoolingEnabledConnector]?: {
+    [sequelizePoolOption in keyof PoolOptions]: LoopbackPoolConfigKey;
+  };
+};
+
+export const ConnectionPoolOptions: IConnectionPoolOptions = {
+  mysql: {
+    max: 'connectionLimit',
+    acquire: 'acquireTimeout',
+  },
+  postgresql: {
+    min: 'min',
+    max: 'max',
+    idle: 'idleTimeoutMillis',
+  },
+  oracle: {
+    min: 'minConn',
+    max: 'maxConn',
+    idle: 'timeout',
+  },
 };

--- a/src/sequelize/sequelize.datasource.base.ts
+++ b/src/sequelize/sequelize.datasource.base.ts
@@ -3,11 +3,17 @@ import {AnyObject} from '@loopback/repository';
 import debugFactory from 'debug';
 import {
   Options as SequelizeOptions,
+  PoolOptions,
   Sequelize,
   Transaction,
   TransactionOptions,
 } from 'sequelize';
 import {
+  ConnectionPoolOptions,
+  LoopbackPoolConfigKey,
+  poolConfigKeys,
+  PoolingEnabledConnector,
+  poolingEnabledConnectors,
   SupportedConnectorMapping as supportedConnectorMapping,
   SupportedLoopbackConnectors,
 } from './connector-mapping';
@@ -60,6 +66,7 @@ export class SequelizeDataSource implements LifeCycleObserver {
       username: user ?? username,
       password,
       logging: queryLogging,
+      pool: this.getPoolOptions(),
     };
 
     this.sequelize = new Sequelize(this.sequelizeConfig);
@@ -113,6 +120,42 @@ export class SequelizeDataSource implements LifeCycleObserver {
     }
 
     return this.sequelize!.transaction(options);
+  }
+
+  getPoolOptions(): PoolOptions | undefined {
+    const config: SequelizeDataSourceConfig = this.config;
+    const specifiedPoolOptions = Object.keys(config).some(key =>
+      poolConfigKeys.includes(key as LoopbackPoolConfigKey),
+    );
+    const supportsPooling =
+      config.connector &&
+      (poolingEnabledConnectors as string[]).includes(config.connector);
+
+    if (!(supportsPooling && specifiedPoolOptions)) {
+      return;
+    }
+    const optionMapping =
+      ConnectionPoolOptions[config.connector as PoolingEnabledConnector];
+
+    if (!optionMapping) {
+      return;
+    }
+
+    const {min, max, acquire, idle} = optionMapping;
+    const options: PoolOptions = {};
+    if (max && config[max]) {
+      options.max = config[max];
+    }
+    if (min && config[min]) {
+      options.min = config[min];
+    }
+    if (acquire && config[acquire]) {
+      options.acquire = config[acquire];
+    }
+    if (idle && config[idle]) {
+      options.idle = config[idle];
+    }
+    return options;
   }
 }
 


### PR DESCRIPTION
## Description

- Added Support for Connection Pooling.
- Forwarding URL option to sequelize from datasource (if received).
- Adds new key in datasource config called `sequelizeOptions` in order to allow users to specify any sequelize specific connection settings.

Fixes #26 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)


## Checklist:

- [x] Performed a self-review of my own code
- [x] npm test passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the style guide
- [x] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
