### PR TITLE
feat(repository): add `defaultFn` support 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "debug": "^4.3.4",
         "sequelize": "^6.28.0",
-        "tslib": "^2.0.0"
+        "tslib": "^2.0.0",
+        "uuid": "^9.0.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^17.4.2",
@@ -30,6 +31,7 @@
         "@semantic-release/release-notes-generator": "^10.0.3",
         "@types/lodash": "^4.14.195",
         "@types/node": "^14.18.36",
+        "@types/uuid": "^9.0.2",
         "commitizen": "^4.3.0",
         "cz-conventional-changelog": "^3.3.0",
         "cz-customizable": "^7.0.0",
@@ -2383,6 +2385,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.2.tgz",
+      "integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==",
+      "dev": true
     },
     "node_modules/@types/validator": {
       "version": "13.7.17",
@@ -15880,7 +15888,6 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
       "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-      "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
   "dependencies": {
     "debug": "^4.3.4",
     "sequelize": "^6.28.0",
-    "tslib": "^2.0.0"
+    "tslib": "^2.0.0",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.4.2",
@@ -72,6 +73,7 @@
     "@semantic-release/release-notes-generator": "^10.0.3",
     "@types/lodash": "^4.14.195",
     "@types/node": "^14.18.36",
+    "@types/uuid": "^9.0.2",
     "commitizen": "^4.3.0",
     "cz-conventional-changelog": "^3.3.0",
     "cz-customizable": "^7.0.0",

--- a/src/__tests__/fixtures/controllers/index.ts
+++ b/src/__tests__/fixtures/controllers/index.ts
@@ -7,6 +7,7 @@ export * from './doctor.controller';
 export * from './patient.controller';
 export * from './product.controller';
 export * from './programming-languange.controller';
+export * from './task.controller';
 export * from './test.controller.base';
 export * from './todo-list-todo.controller';
 export * from './todo-list.controller';

--- a/src/__tests__/fixtures/controllers/task.controller.ts
+++ b/src/__tests__/fixtures/controllers/task.controller.ts
@@ -1,0 +1,186 @@
+import {
+  Count,
+  CountSchema,
+  Filter,
+  FilterExcludingWhere,
+  repository,
+  Where,
+} from '@loopback/repository';
+import {
+  del,
+  get,
+  getModelSchemaRef,
+  param,
+  patch,
+  post,
+  put,
+  requestBody,
+  response,
+} from '@loopback/rest';
+import {Task} from '../models';
+import {TaskRepository} from '../repositories';
+import {TestControllerBase} from './test.controller.base';
+export class TaskController extends TestControllerBase {
+  constructor(
+    @repository(TaskRepository)
+    public taskRepository: TaskRepository,
+  ) {
+    super(taskRepository);
+  }
+
+  @post('/tasks')
+  @response(200, {
+    description: 'task model instance',
+    content: {'application/json': {schema: getModelSchemaRef(Task)}},
+  })
+  async create(
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(Task, {
+            title: 'NewTask',
+            exclude: ['id'],
+          }),
+        },
+      },
+    })
+    task: Omit<Task, 'id'>,
+  ): Promise<Task> {
+    return this.taskRepository.create(task);
+  }
+
+  @post('/tasks-bulk')
+  @response(200, {
+    description: 'task model instances',
+    content: {
+      'application/json': {
+        schema: {
+          type: 'array',
+          items: getModelSchemaRef(Task),
+        },
+      },
+    },
+  })
+  async createAll(
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: {
+            type: 'array',
+            items: getModelSchemaRef(Task, {
+              title: 'NewTask',
+              exclude: ['id'],
+            }),
+          },
+        },
+      },
+    })
+    tasks: Array<Omit<Task, 'id'>>,
+  ): Promise<Task[]> {
+    return this.taskRepository.createAll(tasks);
+  }
+
+  @get('/tasks/count')
+  @response(200, {
+    description: 'Task model count',
+    content: {'application/json': {schema: CountSchema}},
+  })
+  async count(@param.where(Task) where?: Where<Task>): Promise<Count> {
+    return this.taskRepository.count(where);
+  }
+
+  @get('/tasks')
+  @response(200, {
+    description: 'Array of Task model instances',
+    content: {
+      'application/json': {
+        schema: {
+          type: 'array',
+          items: getModelSchemaRef(Task, {includeRelations: true}),
+        },
+      },
+    },
+  })
+  async find(@param.filter(Task) filter?: Filter<Task>): Promise<Task[]> {
+    return this.taskRepository.find(filter);
+  }
+
+  @patch('/tasks')
+  @response(200, {
+    description: 'Task PATCH success count',
+    content: {'application/json': {schema: CountSchema}},
+  })
+  async updateAll(
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(Task, {partial: true}),
+        },
+      },
+    })
+    task: Task,
+    @param.where(Task) where?: Where<Task>,
+  ): Promise<Count> {
+    return this.taskRepository.updateAll(task, where);
+  }
+
+  @get('/tasks/{id}')
+  @response(200, {
+    description: 'Task model instance',
+    content: {
+      'application/json': {
+        schema: getModelSchemaRef(Task, {includeRelations: true}),
+      },
+    },
+  })
+  async findById(
+    @param.path.number('id') id: number,
+    @param.filter(Task, {exclude: 'where'})
+    filter?: FilterExcludingWhere<Task>,
+  ): Promise<Task> {
+    return this.taskRepository.findById(id, filter);
+  }
+
+  @patch('/tasks/{id}')
+  @response(204, {
+    description: 'Task PATCH success',
+  })
+  async updateById(
+    @param.path.number('id') id: number,
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(Task, {partial: true}),
+        },
+      },
+    })
+    task: Task,
+  ): Promise<void> {
+    await this.taskRepository.updateById(id, task);
+  }
+
+  @put('/tasks/{id}')
+  @response(204, {
+    description: 'Task PUT success',
+  })
+  async replaceById(
+    @param.path.number('id') id: number,
+    @requestBody() task: Task,
+  ): Promise<void> {
+    await this.taskRepository.replaceById(id, task);
+  }
+
+  @del('/tasks/{id}')
+  @response(204, {
+    description: 'Task DELETE success',
+  })
+  async deleteById(@param.path.number('id') id: number): Promise<void> {
+    await this.taskRepository.deleteById(id);
+  }
+
+  @get('/tasks/sync-sequelize-model')
+  @response(200)
+  async syncSequelizeModel(): Promise<void> {
+    await this.beforeEach();
+  }
+}

--- a/src/__tests__/fixtures/models/index.ts
+++ b/src/__tests__/fixtures/models/index.ts
@@ -6,6 +6,7 @@ export * from './doctor.model';
 export * from './patient.model';
 export * from './product.model';
 export * from './programming-language.model';
+export * from './task.model';
 export * from './todo-list.model';
 export * from './todo.model';
 export * from './user.model';

--- a/src/__tests__/fixtures/models/task.model.ts
+++ b/src/__tests__/fixtures/models/task.model.ts
@@ -1,0 +1,63 @@
+import {Entity, model, property} from '@loopback/repository';
+
+@model()
+export class Task extends Entity {
+  @property({
+    type: 'number',
+    id: true,
+    generated: true,
+  })
+  id?: number;
+
+  @property({
+    type: 'string',
+    required: true,
+  })
+  title: string;
+
+  @property({
+    type: 'string',
+    defaultFn: 'uuid',
+  })
+  uuidv1: string;
+
+  @property({
+    type: 'string',
+    defaultFn: 'uuidv4',
+  })
+  uuidv4: string;
+
+  @property({
+    type: 'string',
+    defaultFn: 'shortid',
+  })
+  shortId: string;
+
+  @property({
+    type: 'string',
+    defaultFn: 'nanoid',
+  })
+  nanoId: string;
+
+  @property({
+    type: 'number',
+    defaultFn: 'customAlias',
+  })
+  customAlias: number;
+
+  @property({
+    type: 'string',
+    defaultFn: 'now',
+  })
+  createdAt: string;
+
+  constructor(data?: Partial<Task>) {
+    super(data);
+  }
+}
+
+export interface TaskRelations {
+  // describe navigational properties here
+}
+
+export type TaskWithRelations = Task & TaskRelations;

--- a/src/__tests__/fixtures/repositories/index.ts
+++ b/src/__tests__/fixtures/repositories/index.ts
@@ -6,6 +6,7 @@ export * from './doctor.repository';
 export * from './patient.repository';
 export * from './product.repository';
 export * from './programming-language.repository';
+export * from './task.repository';
 export * from './todo-list.repository';
 export * from './todo.repository';
 export * from './user.repository';

--- a/src/__tests__/fixtures/repositories/task.repository.ts
+++ b/src/__tests__/fixtures/repositories/task.repository.ts
@@ -1,0 +1,21 @@
+import {inject} from '@loopback/core';
+import {SequelizeCrudRepository} from '../../../sequelize';
+import {PrimaryDataSource} from '../datasources/primary.datasource';
+import {Task, TaskRelations} from '../models/index';
+
+export class TaskRepository extends SequelizeCrudRepository<
+  Task,
+  typeof Task.prototype.id,
+  TaskRelations
+> {
+  constructor(@inject('datasources.primary') dataSource: PrimaryDataSource) {
+    super(Task, dataSource);
+  }
+
+  protected getDefaultFnRegistry() {
+    return {
+      ...super.getDefaultFnRegistry(),
+      customAlias: () => Math.random(),
+    };
+  }
+}

--- a/src/sequelize/sequelize.repository.base.ts
+++ b/src/sequelize/sequelize.repository.base.ts
@@ -35,6 +35,7 @@ import {
   createReferencesManyAccessor,
 } from '@loopback/repository';
 import debugFactory from 'debug';
+import {nanoid} from 'nanoid';
 import {
   Attributes,
   DataType,
@@ -54,6 +55,7 @@ import {
   WhereOptions,
 } from 'sequelize';
 import {MakeNullishOptional} from 'sequelize/types/utils';
+import * as uuid from 'uuid';
 import {operatorTranslations} from './operator-translation';
 import {SequelizeDataSource} from './sequelize.datasource.base';
 import {SequelizeModel} from './sequelize.model';
@@ -107,6 +109,29 @@ export class SequelizeCrudRepository<
     'mysql',
     'sqlite3',
   ] as const;
+
+  /**
+   * Length of the `nanoid` generated for defaultFn's `shortid` and `nanoid` aliases.
+   */
+  public NANO_ID_LENGTH = 9;
+
+  /**
+   * The alias registry for `defaultFn` option used in model property definition.
+   *
+   * See: https://loopback.io/doc/en/lb4/Model.html#property-decorator
+   */
+  protected defaultFnRegistry: Record<string, () => string | number> = {
+    guid: () => uuid.v1(),
+    uuid: () => uuid.v1(),
+    uuidv4: () => uuid.v4(),
+    now: () => new Date().toJSON(),
+    shortid: () => nanoid(this.NANO_ID_LENGTH),
+    nanoid: () => nanoid(this.NANO_ID_LENGTH),
+  };
+
+  protected getDefaultFnRegistry() {
+    return this.defaultFnRegistry;
+  }
 
   public readonly inclusionResolvers: Map<
     string,
@@ -867,11 +892,18 @@ export class SequelizeCrudRepository<
         );
       }
 
+      let defaultValue = definition[propName].default;
+      const originalDefaultFn = definition[propName]['defaultFn'];
+
+      if (typeof originalDefaultFn === 'function') {
+        defaultValue = originalDefaultFn;
+      } else if (originalDefaultFn in this.getDefaultFnRegistry()) {
+        defaultValue = this.getDefaultFnRegistry()[originalDefaultFn];
+      }
+
       const columnOptions: ModelAttributeColumnOptions = {
         type: dataType,
-        ...('default' in definition[propName]
-          ? {defaultValue: definition[propName].default}
-          : {}),
+        defaultValue,
       };
 
       // Set column as `primaryKey` when id is set to true (which is loopback way to define primary key)


### PR DESCRIPTION
## Description

Added `defaultFn` support with overridable registry of aliases.
The default registry includes existing ones that juggler provides such as uuid, now, shortid etc.

Related: loopbackio/loopback-next#9597

- In Loopback-datasource-juggler cases for "defaultFn" are handled like here: https://github.com/loopbackio/loopback-datasource-juggler/blob/0b9cee7f3b53ca22e716b63db2ed1840d61ef0b2/lib/model.js#L281

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [x] Performed a self-review of my own code
- [x] npm test passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
